### PR TITLE
当内存发生局部重叠的时候应使用memmove

### DIFF
--- a/OpenSourceVersion/audio_buffer.cpp
+++ b/OpenSourceVersion/audio_buffer.cpp
@@ -39,7 +39,7 @@ int audio_buffer::get_data(unsigned char* dest, int how_you_want)
 	else
 	{
 		memcpy(dest, data_, how_you_want);
-		memcpy(data_, data_ + how_you_want, len_ - how_you_want);
+		memmove(data_, data_ + how_you_want, len_ - how_you_want);
 		len_ -= how_you_want;
 		return how_you_want;
 	}   


### PR DESCRIPTION
当内存发生局部重叠的时候，CentOS下memcpy会出现问题，应当使用memmove